### PR TITLE
Config画面の追加・同時読み込み数カスタム機能の試験的追加

### DIFF
--- a/src/main/java/marumasa/marumasa_sign/Config.java
+++ b/src/main/java/marumasa/marumasa_sign/Config.java
@@ -1,5 +1,75 @@
 package marumasa.marumasa_sign;
 
+import com.google.gson.Gson;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static marumasa.marumasa_sign.MarumaSign.MOD_ID;
+
 public class Config {
-    public int MaxThreads = 5;
+    private static final Path path = FabricLoader.getInstance().getConfigDir().normalize().resolve(MOD_ID + ".json");
+
+    private int MaxThreads = 5;
+
+    // 画像の同時ロード数 設定
+    public void setMaxThreads(int value) {
+        MaxThreads = value;
+        serialize();
+    }
+
+    // 画像の同時ロード数 追加
+    public void addMaxThreads(int value) {
+        final int tmp = getMaxThreads() + value;
+        setMaxThreads(tmp);
+    }
+
+    // 画像の同時ロード数 取得
+    public int getMaxThreads() {
+        return MaxThreads;
+    }
+
+    public Config() {
+        final File configFile = path.toFile();
+        if (!configFile.exists()) {
+            serialize();
+        } else {
+            deserialize();
+        }
+    }
+
+    private void deserialize() {
+        final JsonModel model = loadJSON();
+        MaxThreads = model.MaxThreads();
+    }
+
+    private void serialize() {
+        saveJSON(new JsonModel(getMaxThreads()));
+    }
+
+    private static final Gson gson = new Gson();
+
+    private static JsonModel loadJSON() {
+        try (final BufferedReader reader = Files.newBufferedReader(Config.path)) {
+            return gson.fromJson(reader, JsonModel.class);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void saveJSON(JsonModel model) {
+        try (final BufferedWriter writer = Files.newBufferedWriter(Config.path)) {
+            gson.toJson(model, model.getClass(), writer);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private record JsonModel(int MaxThreads) {
+    }
 }

--- a/src/main/java/marumasa/marumasa_sign/client/MarumaSignClient.java
+++ b/src/main/java/marumasa/marumasa_sign/client/MarumaSignClient.java
@@ -2,7 +2,7 @@ package marumasa.marumasa_sign.client;
 
 import marumasa.marumasa_sign.Config;
 import marumasa.marumasa_sign.MarumaSign;
-import marumasa.marumasa_sign.client.sign.CustomSignProvider;
+import marumasa.marumasa_sign.client.screen.ConfigScreen;
 import marumasa.marumasa_sign.http.ServerManager;
 import marumasa.marumasa_sign.util.GifPlayer;
 import marumasa.marumasa_sign.util.ImageRequest;
@@ -21,12 +21,14 @@ import org.lwjgl.glfw.GLFW;
 import java.util.Timer;
 import java.util.TimerTask;
 
+import static net.minecraft.client.MinecraftClient.getInstance;
+
 public class MarumaSignClient implements ClientModInitializer {
 
     // 看板のブロックエンティティタイプ 取得
     private static final BlockEntityType<SignBlockEntity> signType = BlockEntityType.SIGN;
 
-    private static final MinecraftClient client = MinecraftClient.getInstance();
+    private static final MinecraftClient client = getInstance();
 
     @Override
     public void onInitializeClient() {
@@ -58,9 +60,7 @@ public class MarumaSignClient implements ClientModInitializer {
             if (client.player == null) return;
             // もしキーが押されたら
             while (binding2.wasPressed()) {
-                if (ImageRequest.queueSize() != 0) return;
-                CustomSignProvider.removeCache();
-                client.player.sendMessage(Text.translatable("text.maruma_sign.remove_cache"), false);
+                getInstance().setScreen(new ConfigScreen(getInstance().currentScreen));
             }
         });
     }

--- a/src/main/java/marumasa/marumasa_sign/client/MarumaSignClient.java
+++ b/src/main/java/marumasa/marumasa_sign/client/MarumaSignClient.java
@@ -92,7 +92,7 @@ public class MarumaSignClient implements ClientModInitializer {
             @Override
             public void run() {
                 if (client.world == null || client.getBlockRenderManager() == null) return;
-                ImageRequest.load(config.MaxThreads);
+                ImageRequest.load(config.getMaxThreads());
             }
         }
     }

--- a/src/main/java/marumasa/marumasa_sign/client/screen/ConfigScreen.java
+++ b/src/main/java/marumasa/marumasa_sign/client/screen/ConfigScreen.java
@@ -42,14 +42,18 @@ public class ConfigScreen extends Screen {
                 // tooltip設定
                 .tooltip(Tooltip.of(Text.translatable("text.maruma_sign.remove_cache_tooltip")))
                 .build();
-        asyncload_add = ButtonWidget.builder(Text.literal("+"), button -> CONFIG.MaxThreads++)
+        asyncload_add = ButtonWidget.builder(Text.literal("+"), button -> {
+                    // 画像の同時ロード数 を "1" 追加する
+                    CONFIG.addMaxThreads(1);
+                })
                 // レンダリング設定
                 .dimensions(width / 2 - 105, 60, 20, 20)
                 .build();
         asyncload_pull = ButtonWidget.builder(Text.literal("-"), button -> {
                     // 1未満にならないようにチェック
-                    if (CONFIG.MaxThreads > 1) {
-                        CONFIG.MaxThreads--;
+                    if (CONFIG.getMaxThreads() > 1) {
+                        // 画像の同時ロード数 を "-1" 追加する
+                        CONFIG.addMaxThreads(-1);
                     }
                 })
                 // レンダリング設定
@@ -75,6 +79,7 @@ public class ConfigScreen extends Screen {
         // 非同期処理数 ラベルレンダリング
         context.drawCenteredTextWithShadow(textRenderer, Text.translatable("text.maruma_sign.asyncprocessnum"), width / 2 - 155, 65, 0xffffff);
         // 非同期処理数 数字レンダリング
-        context.drawCenteredTextWithShadow(textRenderer, Text.literal(CONFIG.MaxThreads+""), width / 2 - 75, 65, 0xffffff);
+        context.drawCenteredTextWithShadow(textRenderer, Text.literal(CONFIG.getMaxThreads() + ""), width / 2 - 75, 65, 0xffffff);
     }
+
 }

--- a/src/main/java/marumasa/marumasa_sign/client/screen/ConfigScreen.java
+++ b/src/main/java/marumasa/marumasa_sign/client/screen/ConfigScreen.java
@@ -1,0 +1,80 @@
+package marumasa.marumasa_sign.client.screen;
+
+import marumasa.marumasa_sign.client.sign.CustomSignProvider;
+import marumasa.marumasa_sign.util.ImageRequest;
+import net.minecraft.client.gui.DrawContext;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.tooltip.Tooltip;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.text.Text;
+
+import static marumasa.marumasa_sign.MarumaSign.CONFIG;
+import static net.minecraft.client.MinecraftClient.getInstance;
+
+public class ConfigScreen extends Screen {
+    // 親スクリーン取得 (開く前のスクリーン)
+    private final Screen parent;
+
+    public ConfigScreen(Screen parent) {
+        // ナレーションテキスト追加
+        super(Text.literal("MarumaSign Config Screen"));
+        // 親スクリーン設定
+        this.parent = parent;
+    }
+
+    // 各ウィジェット定義
+    public ButtonWidget button_remove_cache; // キャッシュ削除ボタン
+    public ButtonWidget asyncload_add; // 非同期ロード数増加ボタン
+    public ButtonWidget asyncload_pull; // 非同期ロード数減少ボタン
+    public ButtonWidget close_configscreen; // 閉じるボタン
+
+    @Override
+    protected void init() {
+        button_remove_cache = ButtonWidget.builder(Text.translatable("key.marumasa_sign.remove_cache"), button -> {
+                    // MarumaSignClient.java から丸パクリ
+                    if (ImageRequest.queueSize() != 0) return;
+                    CustomSignProvider.removeCache();
+                    getInstance().player.sendMessage(Text.translatable("text.maruma_sign.remove_cache"), false);
+                    getInstance().setScreen(parent);
+                })
+                // レンダリング設定
+                .dimensions(width / 2 - 105, 20, 200, 20)
+                // tooltip設定
+                .tooltip(Tooltip.of(Text.translatable("text.maruma_sign.remove_cache_tooltip")))
+                .build();
+        asyncload_add = ButtonWidget.builder(Text.literal("+"), button -> CONFIG.MaxThreads++)
+                // レンダリング設定
+                .dimensions(width / 2 - 105, 60, 20, 20)
+                .build();
+        asyncload_pull = ButtonWidget.builder(Text.literal("-"), button -> {
+                    // 1未満にならないようにチェック
+                    if (CONFIG.MaxThreads > 1) {
+                        CONFIG.MaxThreads--;
+                    }
+                })
+                // レンダリング設定
+                .dimensions(width / 2 - 45, 60, 20, 20)
+                .build();
+        close_configscreen = ButtonWidget.builder(Text.translatable("text.maruma_sign.close"), button -> {
+                    getInstance().setScreen(parent);
+                })
+                // レンダリング設定
+                .dimensions(width / 2 - 105, height - 20, 200, 20)
+                .build();
+
+        // 選択可能状態でレンダリング
+        addDrawableChild(button_remove_cache);
+        addDrawableChild(asyncload_add);
+        addDrawableChild(asyncload_pull);
+        addDrawableChild(close_configscreen);
+    }
+
+    @Override
+    public void render(DrawContext context, int mouseX, int mouseY, float delta) {
+        super.render(context, mouseX, mouseY, delta);
+        // 非同期処理数 ラベルレンダリング
+        context.drawCenteredTextWithShadow(textRenderer, Text.translatable("text.maruma_sign.asyncprocessnum"), width / 2 - 155, 65, 0xffffff);
+        // 非同期処理数 数字レンダリング
+        context.drawCenteredTextWithShadow(textRenderer, Text.literal(CONFIG.MaxThreads+""), width / 2 - 75, 65, 0xffffff);
+    }
+}

--- a/src/main/resources/assets/marumasa_sign/lang/en_us.json
+++ b/src/main/resources/assets/marumasa_sign/lang/en_us.json
@@ -3,5 +3,8 @@
   "text.maruma_sign.open_menu": "Open WebUI...",
   "key.marumasa_sign.open_menu": "Open WebUI",
   "key.marumasa_sign.remove_cache": "Delete cache",
-  "key.categories.marumasa_sign": "MarumaSign"
+  "key.categories.marumasa_sign": "MarumaSign",
+  "text.maruma_sign.remove_cache_tooltip": "Delete Image Cache of MarumaSign",
+  "text.maruma_sign.asyncprocessnum": " Simultaneous image loads",
+  "text.maruma_sign.close": "Close"
 }

--- a/src/main/resources/assets/marumasa_sign/lang/ja_jp.json
+++ b/src/main/resources/assets/marumasa_sign/lang/ja_jp.json
@@ -3,5 +3,8 @@
   "text.maruma_sign.open_menu": "WebUIを開いています...",
   "key.marumasa_sign.open_menu": "WebUIを開く",
   "key.marumasa_sign.remove_cache": "キャッシュを削除する",
-  "key.categories.marumasa_sign": "MarumaSign"
+  "key.categories.marumasa_sign": "MarumaSign",
+  "text.maruma_sign.remove_cache_tooltip": "MarumaSignの画像キャッシュをすべて削除します",
+  "text.maruma_sign.asyncprocessnum": "画像の同時ロード数",
+  "text.maruma_sign.close": "閉じる"
 }


### PR DESCRIPTION
# 概要
このプルでは主に3つの変更が追加されます

- Mキーをキャッシュ削除からコンフィグへ変更
- それに伴いキャッシュ削除機能はコンフィグから呼び出せるように変更
- MarumaSignの同時読み込み数をカスタマイズできるように変更 **(試験的機能)**

![image](https://github.com/TORO-Server/MarumaSign/assets/120289597/9ef33916-61f3-4de7-bff7-2d0cd7cb4c2a)

## `ConfigScreen.java` について連絡
今後の機能追加でさらに設定が必要な場合は、ConfigScreenクラスのinitメソッドにある他のコードを参照して追加してください

**GUIを実装するにあたってサードパーティー製ツールキットは使用しておりません (APIだけでレンダリングしております)**

## 画像の同時読み込み数カスタム機能について連絡
現在、どのプラットフォームでも安全性が確保できている訳ではないので、まだ試験段階としてコミットしてあります。

**今後修正・追加していきたい機能**

- 次回起動時も設定が保持される
- フレームレートでいう垂直同期 (動的読み込み) 機能